### PR TITLE
Added basic TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,165 @@
+declare module "codec-parser"
+{
+    declare type OggMimeType = "application/ogg" | "audio/ogg";
+    declare type FramedMimeType = "audio/mpeg" | "audio/aac" | "audio/aacp" | "audio/flac";
+    declare type MimeType = FramedMimeType | OggMimeType;
+
+    declare class MPEGHeader
+    {
+        public bitDepth: number;
+        public bitrate: number;
+        public channels: number;
+        public sampleRate: number;
+        public channelMode: string;
+        public emphasis: string;
+        public framePadding: number;
+        public isCopyrighted: boolean;
+        public isOriginal: boolean;
+        public isPrivate: boolean;
+        public layer: string;
+        public modeExtension: string;
+        public mpegVersion: string;
+        public protection: string;
+    }
+
+    declare class AACHeader
+    {
+        public bitDepth: number;
+        public bitrate: number;
+        public channels: number;
+        public sampleRate: number;
+        public copyrightId: boolean;
+        public copyrightIdStart: boolean;
+        public channelMode: string;
+        public bufferFullness: string;
+        public isHome: boolean;
+        public isOriginal: boolean;
+        public isPrivate: boolean;
+        public layer: string;
+        public length: number;
+        public mpegVersion: string;
+        public numberAACFrames: number;
+        public profile: string;
+        public protection: string;
+    }
+
+    declare class FLACHeader
+    {
+        public bitDepth: number;
+        public bitrate: number;
+        public channels: number;
+        public sampleRate: number;
+        public channelMode: string;
+        public blockingStrategy: string;
+        public blockSize: number;
+        public frameNumber: number;
+        public crc16: number;
+        public streamInfo: Uint8Array;
+    }
+
+    declare class OpusHeader
+    {
+        public bitDepth: number;
+        public bitrate: number;
+        public channels: number;
+        public data: Uint8Array;
+        public sampleRate: number;
+        public bandwidth: string;
+        public channelMappingFamily: number;
+        public channelMappingTable: number[];
+        public coupledStreamCount: number;
+        public streamCount: number;
+        public channelMode: string;
+        public frameCount: number;
+        public frameSize: number;
+        public inputSampleRate: number;
+        public mode: string;
+        public outputGain: number;
+        public preSkip: number;
+    }
+
+    declare class VorbisHeader
+    {
+        public bitDepth: number;
+        public bitrate: number;
+        public channels: number;
+        public channelMode: string;
+        public sampleRate: number;
+        public bitrateMaximum: number;
+        public bitrateMinimum: number;
+        public bitrateNominal: number;
+        public blocksize0: number;
+        public blocksize1: number;
+        public data: Uint8Array;
+        public vorbisComments: Uint8Array;
+        public vorbisSetup: Uint8Array;
+    }
+
+    declare class CodecFrame
+    {
+        public data: Uint8Array;
+        public header: MPEGHeader | AACHeader | FLACHeader | OpusHeader | VorbisHeader;
+        public crc32: number;
+        public samples: number;
+        public duration: number;
+        public frameNumber: number;
+        public totalBytesOut: number;
+        public totalSamples: number;
+        public totalDuration: number;
+    }
+
+    declare class OggPage
+    {
+        public absoluteGranulePosition: number;
+        public codecFrames: CodecFrame[];
+        public crc32: number;
+        public data: Uint8Array;
+        public duration: number;
+        public isContinuedPacket: boolean;
+        public isFirstPage: boolean;
+        public isLastPage: boolean;
+        public pageSequenceNumber: number;
+        public rawData: Uint8Array;
+        public samples: number;
+        public streamSerialNumber: number;
+        public totalBytesOut: number;
+        public totalDuration: number;
+        public totalSamples: number;
+    }
+
+    declare interface ICodecParserOptions
+    {
+        onCodec?: () => any;
+        onCodecUpdate?: () => any;
+        enableLogging?: boolean;
+    }
+
+    declare class CodecParser<T extends CodecFrame | OggPage = CodecFrame | OggPage>
+    {
+        public readonly codec: string;
+
+        constructor(mimeType: FramedMimeType, options?: ICodecParserOptions): CodecParser<CodecFrame>;
+        constructor(mimeType: OggMimeType, options?: ICodecParserOptions): CodecParser<OggPage>;
+        constructor(mimeType: MimeType, options?: ICodecParserOptions);
+
+        public parseAll(file: Uint8Array): T[];
+        public parseChunk(chunk: Uint8Array): Iterator<T>;
+        public flush(): Iterator<T>;
+    }
+
+    export = CodecParser;
+
+    export type {
+        MPEGHeader,
+        AACHeader,
+        CodecFrame,
+        FLACHeader,
+        ICodecParserOptions,
+        OggPage,
+        OpusHeader,
+        VorbisHeader,
+        MimeType,
+        OggMimeType,
+        FramedMimeType
+    };
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,165 +1,172 @@
-declare module "codec-parser"
-{
-    declare type OggMimeType = "application/ogg" | "audio/ogg";
-    declare type FramedMimeType = "audio/mpeg" | "audio/aac" | "audio/aacp" | "audio/flac";
-    declare type MimeType = FramedMimeType | OggMimeType;
+declare module "codec-parser" {
+  declare type OggMimeType = "application/ogg" | "audio/ogg";
+  declare type FramedMimeType =
+    | "audio/mpeg"
+    | "audio/aac"
+    | "audio/aacp"
+    | "audio/flac";
+  declare type MimeType = FramedMimeType | OggMimeType;
 
-    declare class MPEGHeader
-    {
-        public bitDepth: number;
-        public bitrate: number;
-        public channels: number;
-        public sampleRate: number;
-        public channelMode: string;
-        public emphasis: string;
-        public framePadding: number;
-        public isCopyrighted: boolean;
-        public isOriginal: boolean;
-        public isPrivate: boolean;
-        public layer: string;
-        public modeExtension: string;
-        public mpegVersion: string;
-        public protection: string;
-    }
+  declare class MPEGHeader {
+    public bitDepth: number;
+    public bitrate: number;
+    public channels: number;
+    public sampleRate: number;
+    public channelMode: string;
+    public emphasis: string;
+    public framePadding: number;
+    public isCopyrighted: boolean;
+    public isOriginal: boolean;
+    public isPrivate: boolean;
+    public layer: string;
+    public modeExtension: string;
+    public mpegVersion: string;
+    public protection: string;
+  }
 
-    declare class AACHeader
-    {
-        public bitDepth: number;
-        public bitrate: number;
-        public channels: number;
-        public sampleRate: number;
-        public copyrightId: boolean;
-        public copyrightIdStart: boolean;
-        public channelMode: string;
-        public bufferFullness: string;
-        public isHome: boolean;
-        public isOriginal: boolean;
-        public isPrivate: boolean;
-        public layer: string;
-        public length: number;
-        public mpegVersion: string;
-        public numberAACFrames: number;
-        public profile: string;
-        public protection: string;
-    }
+  declare class AACHeader {
+    public bitDepth: number;
+    public bitrate: number;
+    public channels: number;
+    public sampleRate: number;
+    public copyrightId: boolean;
+    public copyrightIdStart: boolean;
+    public channelMode: string;
+    public bufferFullness: string;
+    public isHome: boolean;
+    public isOriginal: boolean;
+    public isPrivate: boolean;
+    public layer: string;
+    public length: number;
+    public mpegVersion: string;
+    public numberAACFrames: number;
+    public profile: string;
+    public protection: string;
+  }
 
-    declare class FLACHeader
-    {
-        public bitDepth: number;
-        public bitrate: number;
-        public channels: number;
-        public sampleRate: number;
-        public channelMode: string;
-        public blockingStrategy: string;
-        public blockSize: number;
-        public frameNumber: number;
-        public crc16: number;
-        public streamInfo: Uint8Array;
-    }
+  declare class FLACHeader {
+    public bitDepth: number;
+    public bitrate: number;
+    public channels: number;
+    public sampleRate: number;
+    public channelMode: string;
+    public blockingStrategy: string;
+    public blockSize: number;
+    public frameNumber: number;
+    public crc16: number;
+    public streamInfo: Uint8Array;
+  }
 
-    declare class OpusHeader
-    {
-        public bitDepth: number;
-        public bitrate: number;
-        public channels: number;
-        public data: Uint8Array;
-        public sampleRate: number;
-        public bandwidth: string;
-        public channelMappingFamily: number;
-        public channelMappingTable: number[];
-        public coupledStreamCount: number;
-        public streamCount: number;
-        public channelMode: string;
-        public frameCount: number;
-        public frameSize: number;
-        public inputSampleRate: number;
-        public mode: string;
-        public outputGain: number;
-        public preSkip: number;
-    }
+  declare class OpusHeader {
+    public bitDepth: number;
+    public bitrate: number;
+    public channels: number;
+    public data: Uint8Array;
+    public sampleRate: number;
+    public bandwidth: string;
+    public channelMappingFamily: number;
+    public channelMappingTable: number[];
+    public coupledStreamCount: number;
+    public streamCount: number;
+    public channelMode: string;
+    public frameCount: number;
+    public frameSize: number;
+    public inputSampleRate: number;
+    public mode: string;
+    public outputGain: number;
+    public preSkip: number;
+  }
 
-    declare class VorbisHeader
-    {
-        public bitDepth: number;
-        public bitrate: number;
-        public channels: number;
-        public channelMode: string;
-        public sampleRate: number;
-        public bitrateMaximum: number;
-        public bitrateMinimum: number;
-        public bitrateNominal: number;
-        public blocksize0: number;
-        public blocksize1: number;
-        public data: Uint8Array;
-        public vorbisComments: Uint8Array;
-        public vorbisSetup: Uint8Array;
-    }
+  declare class VorbisHeader {
+    public bitDepth: number;
+    public bitrate: number;
+    public channels: number;
+    public channelMode: string;
+    public sampleRate: number;
+    public bitrateMaximum: number;
+    public bitrateMinimum: number;
+    public bitrateNominal: number;
+    public blocksize0: number;
+    public blocksize1: number;
+    public data: Uint8Array;
+    public vorbisComments: Uint8Array;
+    public vorbisSetup: Uint8Array;
+  }
 
-    declare class CodecFrame
-    {
-        public data: Uint8Array;
-        public header: MPEGHeader | AACHeader | FLACHeader | OpusHeader | VorbisHeader;
-        public crc32: number;
-        public samples: number;
-        public duration: number;
-        public frameNumber: number;
-        public totalBytesOut: number;
-        public totalSamples: number;
-        public totalDuration: number;
-    }
+  declare class CodecFrame {
+    public data: Uint8Array;
+    public header:
+      | MPEGHeader
+      | AACHeader
+      | FLACHeader
+      | OpusHeader
+      | VorbisHeader;
+    public crc32: number;
+    public samples: number;
+    public duration: number;
+    public frameNumber: number;
+    public totalBytesOut: number;
+    public totalSamples: number;
+    public totalDuration: number;
+  }
 
-    declare class OggPage
-    {
-        public absoluteGranulePosition: number;
-        public codecFrames: CodecFrame[];
-        public crc32: number;
-        public data: Uint8Array;
-        public duration: number;
-        public isContinuedPacket: boolean;
-        public isFirstPage: boolean;
-        public isLastPage: boolean;
-        public pageSequenceNumber: number;
-        public rawData: Uint8Array;
-        public samples: number;
-        public streamSerialNumber: number;
-        public totalBytesOut: number;
-        public totalDuration: number;
-        public totalSamples: number;
-    }
+  declare class OggPage {
+    public absoluteGranulePosition: number;
+    public codecFrames: CodecFrame[];
+    public crc32: number;
+    public data: Uint8Array;
+    public duration: number;
+    public isContinuedPacket: boolean;
+    public isFirstPage: boolean;
+    public isLastPage: boolean;
+    public pageSequenceNumber: number;
+    public rawData: Uint8Array;
+    public samples: number;
+    public streamSerialNumber: number;
+    public totalBytesOut: number;
+    public totalDuration: number;
+    public totalSamples: number;
+  }
 
-    declare interface ICodecParserOptions
-    {
-        onCodec?: () => any;
-        onCodecUpdate?: () => any;
-        enableLogging?: boolean;
-    }
+  declare interface ICodecParserOptions {
+    onCodec?: () => any;
+    onCodecUpdate?: () => any;
+    enableLogging?: boolean;
+  }
 
-    declare class CodecParser<T extends CodecFrame | OggPage = CodecFrame | OggPage>
-    {
-        public readonly codec: string;
+  declare class CodecParser<
+    T extends CodecFrame | OggPage = CodecFrame | OggPage
+  > {
+    public readonly codec: string;
 
-        constructor(mimeType: FramedMimeType, options?: ICodecParserOptions): CodecParser<CodecFrame>;
-        constructor(mimeType: OggMimeType, options?: ICodecParserOptions): CodecParser<OggPage>;
-        constructor(mimeType: MimeType, options?: ICodecParserOptions);
+    constructor(
+      mimeType: FramedMimeType,
+      options?: ICodecParserOptions
+    ): CodecParser<CodecFrame>;
+    constructor(
+      mimeType: OggMimeType,
+      options?: ICodecParserOptions
+    ): CodecParser<OggPage>;
+    constructor(mimeType: MimeType, options?: ICodecParserOptions);
 
-        public parseAll(file: Uint8Array): T[];
-        public parseChunk(chunk: Uint8Array): Iterator<T>;
-        public flush(): Iterator<T>;
-    }
+    public parseAll(file: Uint8Array): T[];
+    public parseChunk(chunk: Uint8Array): Iterator<T>;
+    public flush(): Iterator<T>;
+  }
 
-    export = CodecParser;
+  export = CodecParser;
 
-    export type {
-        MPEGHeader,
-        AACHeader,
-        CodecFrame,
-        FLACHeader,
-        ICodecParserOptions,
-        OggPage,
-        OpusHeader,
-        VorbisHeader,
-        MimeType,
-        OggMimeType,
-        FramedMimeType
-    };
+  export type {
+    MPEGHeader,
+    AACHeader,
+    CodecFrame,
+    FLACHeader,
+    ICodecParserOptions,
+    OggPage,
+    OpusHeader,
+    VorbisHeader,
+    MimeType,
+    OggMimeType,
+    FramedMimeType,
+  };
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,172 +1,166 @@
-declare module "codec-parser" {
-  declare type OggMimeType = "application/ogg" | "audio/ogg";
-  declare type FramedMimeType =
-    | "audio/mpeg"
-    | "audio/aac"
-    | "audio/aacp"
-    | "audio/flac";
-  declare type MimeType = FramedMimeType | OggMimeType;
+declare type OggMimeType = "application/ogg" | "audio/ogg";
+declare type FramedMimeType =
+  | "audio/mpeg"
+  | "audio/aac"
+  | "audio/aacp"
+  | "audio/flac";
+declare type MimeType = FramedMimeType | OggMimeType;
 
-  declare class MPEGHeader {
-    public bitDepth: number;
-    public bitrate: number;
-    public channels: number;
-    public sampleRate: number;
-    public channelMode: string;
-    public emphasis: string;
-    public framePadding: number;
-    public isCopyrighted: boolean;
-    public isOriginal: boolean;
-    public isPrivate: boolean;
-    public layer: string;
-    public modeExtension: string;
-    public mpegVersion: string;
-    public protection: string;
-  }
-
-  declare class AACHeader {
-    public bitDepth: number;
-    public bitrate: number;
-    public channels: number;
-    public sampleRate: number;
-    public copyrightId: boolean;
-    public copyrightIdStart: boolean;
-    public channelMode: string;
-    public bufferFullness: string;
-    public isHome: boolean;
-    public isOriginal: boolean;
-    public isPrivate: boolean;
-    public layer: string;
-    public length: number;
-    public mpegVersion: string;
-    public numberAACFrames: number;
-    public profile: string;
-    public protection: string;
-  }
-
-  declare class FLACHeader {
-    public bitDepth: number;
-    public bitrate: number;
-    public channels: number;
-    public sampleRate: number;
-    public channelMode: string;
-    public blockingStrategy: string;
-    public blockSize: number;
-    public frameNumber: number;
-    public crc16: number;
-    public streamInfo: Uint8Array;
-  }
-
-  declare class OpusHeader {
-    public bitDepth: number;
-    public bitrate: number;
-    public channels: number;
-    public data: Uint8Array;
-    public sampleRate: number;
-    public bandwidth: string;
-    public channelMappingFamily: number;
-    public channelMappingTable: number[];
-    public coupledStreamCount: number;
-    public streamCount: number;
-    public channelMode: string;
-    public frameCount: number;
-    public frameSize: number;
-    public inputSampleRate: number;
-    public mode: string;
-    public outputGain: number;
-    public preSkip: number;
-  }
-
-  declare class VorbisHeader {
-    public bitDepth: number;
-    public bitrate: number;
-    public channels: number;
-    public channelMode: string;
-    public sampleRate: number;
-    public bitrateMaximum: number;
-    public bitrateMinimum: number;
-    public bitrateNominal: number;
-    public blocksize0: number;
-    public blocksize1: number;
-    public data: Uint8Array;
-    public vorbisComments: Uint8Array;
-    public vorbisSetup: Uint8Array;
-  }
-
-  declare class CodecFrame {
-    public data: Uint8Array;
-    public header:
-      | MPEGHeader
-      | AACHeader
-      | FLACHeader
-      | OpusHeader
-      | VorbisHeader;
-    public crc32: number;
-    public samples: number;
-    public duration: number;
-    public frameNumber: number;
-    public totalBytesOut: number;
-    public totalSamples: number;
-    public totalDuration: number;
-  }
-
-  declare class OggPage {
-    public absoluteGranulePosition: number;
-    public codecFrames: CodecFrame[];
-    public crc32: number;
-    public data: Uint8Array;
-    public duration: number;
-    public isContinuedPacket: boolean;
-    public isFirstPage: boolean;
-    public isLastPage: boolean;
-    public pageSequenceNumber: number;
-    public rawData: Uint8Array;
-    public samples: number;
-    public streamSerialNumber: number;
-    public totalBytesOut: number;
-    public totalDuration: number;
-    public totalSamples: number;
-  }
-
-  declare interface ICodecParserOptions {
-    onCodec?: () => any;
-    onCodecUpdate?: () => any;
-    enableLogging?: boolean;
-  }
-
-  declare class CodecParser<
-    T extends CodecFrame | OggPage = CodecFrame | OggPage
-  > {
-    public readonly codec: string;
-
-    constructor(
-      mimeType: FramedMimeType,
-      options?: ICodecParserOptions
-    ): CodecParser<CodecFrame>;
-    constructor(
-      mimeType: OggMimeType,
-      options?: ICodecParserOptions
-    ): CodecParser<OggPage>;
-    constructor(mimeType: MimeType, options?: ICodecParserOptions);
-
-    public parseAll(file: Uint8Array): T[];
-    public parseChunk(chunk: Uint8Array): Iterator<T>;
-    public flush(): Iterator<T>;
-  }
-
-  export = CodecParser;
-
-  export type {
-    MPEGHeader,
-    AACHeader,
-    CodecFrame,
-    FLACHeader,
-    ICodecParserOptions,
-    OggPage,
-    OpusHeader,
-    VorbisHeader,
-    MimeType,
-    OggMimeType,
-    FramedMimeType,
-  };
+declare class MPEGHeader {
+  public bitDepth: number;
+  public bitrate: number;
+  public channels: number;
+  public sampleRate: number;
+  public channelMode: string;
+  public emphasis: string;
+  public framePadding: number;
+  public isCopyrighted: boolean;
+  public isOriginal: boolean;
+  public isPrivate: boolean;
+  public layer: string;
+  public modeExtension: string;
+  public mpegVersion: string;
+  public protection: string;
 }
+
+declare class AACHeader {
+  public bitDepth: number;
+  public bitrate: number;
+  public channels: number;
+  public sampleRate: number;
+  public copyrightId: boolean;
+  public copyrightIdStart: boolean;
+  public channelMode: string;
+  public bufferFullness: string;
+  public isHome: boolean;
+  public isOriginal: boolean;
+  public isPrivate: boolean;
+  public layer: string;
+  public length: number;
+  public mpegVersion: string;
+  public numberAACFrames: number;
+  public profile: string;
+  public protection: string;
+}
+
+declare class FLACHeader {
+  public bitDepth: number;
+  public bitrate: number;
+  public channels: number;
+  public sampleRate: number;
+  public channelMode: string;
+  public blockingStrategy: string;
+  public blockSize: number;
+  public frameNumber: number;
+  public crc16: number;
+  public streamInfo: Uint8Array;
+}
+
+declare class OpusHeader {
+  public bitDepth: number;
+  public bitrate: number;
+  public channels: number;
+  public data: Uint8Array;
+  public sampleRate: number;
+  public bandwidth: string;
+  public channelMappingFamily: number;
+  public channelMappingTable: number[];
+  public coupledStreamCount: number;
+  public streamCount: number;
+  public channelMode: string;
+  public frameCount: number;
+  public frameSize: number;
+  public inputSampleRate: number;
+  public mode: string;
+  public outputGain: number;
+  public preSkip: number;
+}
+
+declare class VorbisHeader {
+  public bitDepth: number;
+  public bitrate: number;
+  public channels: number;
+  public channelMode: string;
+  public sampleRate: number;
+  public bitrateMaximum: number;
+  public bitrateMinimum: number;
+  public bitrateNominal: number;
+  public blocksize0: number;
+  public blocksize1: number;
+  public data: Uint8Array;
+  public vorbisComments: Uint8Array;
+  public vorbisSetup: Uint8Array;
+}
+
+declare class CodecFrame {
+  public data: Uint8Array;
+  public header:
+    | MPEGHeader
+    | AACHeader
+    | FLACHeader
+    | OpusHeader
+    | VorbisHeader;
+  public crc32: number;
+  public samples: number;
+  public duration: number;
+  public frameNumber: number;
+  public totalBytesOut: number;
+  public totalSamples: number;
+  public totalDuration: number;
+}
+
+declare class OggPage {
+  public absoluteGranulePosition: number;
+  public codecFrames: CodecFrame[];
+  public crc32: number;
+  public data: Uint8Array;
+  public duration: number;
+  public isContinuedPacket: boolean;
+  public isFirstPage: boolean;
+  public isLastPage: boolean;
+  public pageSequenceNumber: number;
+  public rawData: Uint8Array;
+  public samples: number;
+  public streamSerialNumber: number;
+  public totalBytesOut: number;
+  public totalDuration: number;
+  public totalSamples: number;
+}
+
+declare interface ICodecParserOptions {
+  onCodec?: () => any;
+  onCodecUpdate?: () => any;
+  enableLogging?: boolean;
+}
+
+declare class CodecParser<
+  T extends CodecFrame | OggPage = CodecFrame | OggPage
+> {
+  public readonly codec: string;
+
+  constructor(mimeType: FramedMimeType, options?: ICodecParserOptions);
+
+  constructor(mimeType: OggMimeType, options?: ICodecParserOptions);
+
+  constructor(mimeType: MimeType, options?: ICodecParserOptions);
+
+  public parseAll(file: Uint8Array): T[];
+  public parseChunk(chunk: Uint8Array): Iterator<T>;
+  public flush(): Iterator<T>;
+}
+
+export default CodecParser;
+
+export type {
+  MPEGHeader,
+  AACHeader,
+  CodecFrame,
+  FLACHeader,
+  ICodecParserOptions,
+  OggPage,
+  OpusHeader,
+  VorbisHeader,
+  MimeType,
+  OggMimeType,
+  FramedMimeType,
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ declare type FramedMimeType =
   | "audio/aacp"
   | "audio/flac";
 declare type MimeType = FramedMimeType | OggMimeType;
+declare type CodecValue = "mpeg" | "aac" | "flac" | "opus" | "vorbis";
 
 declare class MPEGHeader {
   public bitDepth: number;
@@ -92,14 +93,16 @@ declare class VorbisHeader {
   public vorbisSetup: Uint8Array;
 }
 
+declare type CodecHeader =
+  | MPEGHeader
+  | AACHeader
+  | FLACHeader
+  | OpusHeader
+  | VorbisHeader;
+
 declare class CodecFrame {
   public data: Uint8Array;
-  public header:
-    | MPEGHeader
-    | AACHeader
-    | FLACHeader
-    | OpusHeader
-    | VorbisHeader;
+  public header: CodecHeader;
   public crc32: number;
   public samples: number;
   public duration: number;
@@ -128,15 +131,18 @@ declare class OggPage {
 }
 
 declare interface ICodecParserOptions {
-  onCodec?: () => any;
-  onCodecUpdate?: () => any;
+  onCodec?: (codec: CodecValue) => any;
+  onCodecUpdate?: (
+    codecHeaderData: CodecHeader,
+    updateTimestamp: number
+  ) => any;
   enableLogging?: boolean;
 }
 
 declare class CodecParser<
   T extends CodecFrame | OggPage = CodecFrame | OggPage
 > {
-  public readonly codec: string;
+  public readonly codec: CodecValue;
 
   constructor(mimeType: FramedMimeType, options?: ICodecParserOptions);
 
@@ -152,6 +158,8 @@ declare class CodecParser<
 export default CodecParser;
 
 export type {
+  CodecValue,
+  CodecHeader,
   MPEGHeader,
   AACHeader,
   CodecFrame,

--- a/index.d.ts
+++ b/index.d.ts
@@ -144,10 +144,6 @@ declare class CodecParser<
 > {
   public readonly codec: CodecValue;
 
-  constructor(mimeType: FramedMimeType, options?: ICodecParserOptions);
-
-  constructor(mimeType: OggMimeType, options?: ICodecParserOptions);
-
   constructor(mimeType: MimeType, options?: ICodecParserOptions);
 
   public parseAll(file: Uint8Array): T[];

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.2",
   "description": "Library that parses raw data from audio codecs into frames containing data, header values, duration, and other information.",
   "main": "index.js",
+  "types": "index.d.ts",
   "keywords": [
     "mp3",
     "mpeg",
@@ -38,6 +39,5 @@
     "@types/jest": "^27.5.1",
     "jest": "^28.1.0",
     "prettier": "^2.6.2"
-  },
-  "types": "index.d.ts"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/.bin/jest --maxWorkers=100% --coverage --no-color 2> test-results.txt && echo \"Open test-results.txt to view the test results\"",
-    "format": "prettier --write '**/*.js' --write 'package.json'"
+    "format": "prettier --write \"**/*.js\" --write \"package.json\" --write \"**/*.d.ts\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -38,5 +38,6 @@
     "@types/jest": "^27.5.1",
     "jest": "^28.1.0",
     "prettier": "^2.6.2"
-  }
+  },
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
This PR adds `index.d.ts` containing typings, but without descriptions (as of now). This allows `codec-parser` to be used in TypeScript projects nicely.

There are no changes to runtime code, these are merely declarations for IntelliSense, etc. to work better.